### PR TITLE
CopyleaksAuthToken class refactor

### DIFF
--- a/src/main/java/models/response/CopyleaksAuthToken.java
+++ b/src/main/java/models/response/CopyleaksAuthToken.java
@@ -30,6 +30,18 @@ public class CopyleaksAuthToken {
     @SerializedName(".expires")
     private String expires;
 
+    public CopyleaksAuthToken(String accessToken, String issued, String expires) {
+        this.accessToken = accessToken;
+        this.issued = issued;
+        this.expires = expires;
+    }
+
+    public CopyleaksAuthToken(CopyleaksAuthToken authToken) {
+        this.accessToken = authToken.accessToken;
+        this.issued = authToken.issued;
+        this.expires = authToken.expires;
+    }
+
     public String getAccessToken() {
         return accessToken;
     }
@@ -42,7 +54,15 @@ public class CopyleaksAuthToken {
         return issued;
     }
 
+    public void setIssued(String issued) {
+        this.issued = issued;
+    }
+
     public String getExpires() {
         return expires;
+    }
+
+    public void setExpires(String expires) {
+        this.expires = expires;
     }
 }


### PR DESCRIPTION
- added missing setters for `issued` and `expires` properties.
- added constructors.